### PR TITLE
added make targets for building primme as a shared library

### DIFF
--- a/Make_flags
+++ b/Make_flags
@@ -7,6 +7,9 @@
 LIBRARY = libprimme.a
 DLIBRARY = libdprimme.a
 ZLIBRARY = libzprimme.a
+SOLIBRARY = libprimme.so
+DSOLIBRARY = libdprimme.so
+ZSOLIBRARY = libzprimme.so
 
 # Define compilers and flags
 #---------------------------------------------------------------
@@ -56,6 +59,12 @@ FFLAGS   ?= -fno-second-underscore -O
 # Cray architectures
 # CFLAGS += -O3 -march=native -mtune=native -funroll-loops  -ffast-math -fstrict-aliasing  -std=gnu99 -msse2 -msse3
 
+#---------------------------------------------------------------
+# Uncomment this to generate position independent code
+# (needed if primme is compiled as a shared library)
+CFLAGS += -fPIC
+FFLAGS += -fPIC
+#---------------------------------------------------------------
 
 #---------------------------------------------------------------
 # Uncomment this when building MATLAB interface

--- a/makefile
+++ b/makefile
@@ -20,6 +20,8 @@ lib:
 	echo "-----------------------------------"; \
 	make lib;\
 	)
+solib: lib
+	$(CC) -shared -o $(SOLIBRARY) -Wl,--whole-archive $(LIBRARY) -Wl,--no-whole-archive
 
 libd:
 	@(\
@@ -29,6 +31,8 @@ libd:
 	echo "---------------------------------------"; \
 	make libd;\
 	)
+solibd: libd
+	$(CC) -shared -o $(DSOLIBRARY) -Wl,--whole-archive $(DLIBRARY) -Wl,--no-whole-archive
 
 libz:
 	@(\
@@ -38,6 +42,9 @@ libz:
 	echo "----------------------------------------"; \
 	make libz;\
 	)
+solibz: libz
+	$(CC) -shared -o $(ZSOLIBRARY) -Wl,--whole-archive $(ZLIBRARY) -Wl,--no-whole-archive
+
 clean: 
 	@(\
 	echo "--------------------------------------------------"; \

--- a/readme.txt
+++ b/readme.txt
@@ -257,7 +257,9 @@ The next directories and files should be available:
 * "TEST/",         sample test programs in C and F77, both
   sequential and parallel;
 
-* "libprimme.a",   the PRIMME library (to be made);
+* "libprimme.a",   the PRIMME static library (to be made);
+
+* "libprimme.so",  the PRIMME shared library (to be made);
 
 * "makefile"       main make file;
 
@@ -345,6 +347,14 @@ Full description of actions that *make* can take:
 
 * *make libz*, if only "zprimme()" is of interest, build
   "libzprimme.a";
+
+* *make solib*, builds "libprimme.so"; alternatively:
+
+* *make solibd*, if only "dprimme()" is of interest, build
+  "libdprimme.so":
+
+* *make solibz*, if only "zprimme()" is of interest, build
+  "libzprimme.so";
 
 * *make test*, build and execute a simple example;
 


### PR DESCRIPTION
The primme build system currently does not support building primme as a
shared library. This is insofar unfortunate as the LGPL license does not
permit static linking into proprietary software. I have added three
build targets (solib, solibd, solibz) that build shared versions of the
primme library to the makefile. This works by taking the static
library and dumping its contents into a shared object, so the changes
are quite minimal. Note that -fPIC has to be enabled in the Make_flags
file if a shared library is to be built.