### PR TITLE
Fix for outputFile in Fortran interface

### DIFF
--- a/PRIMMESRC/COMMONSRC/primme_f77.c
+++ b/PRIMMESRC/COMMONSRC/primme_f77.c
@@ -315,7 +315,7 @@ void primme_set_member_f77(primme_params **primme, int *label, union f77_value v
               (*primme)->printLevel = *v.int_v;
       break;
       case PRIMMEF77_outputFile:
-              (*primme)->outputFile = v.file_v;
+              (*primme)->outputFile = *v.file_v;
       break;
       case PRIMMEF77_matrix:
               (*primme)->matrix = v.ptr_v;

--- a/PRIMMESRC/COMMONSRC/primme_f77_private.h
+++ b/PRIMMESRC/COMMONSRC/primme_f77_private.h
@@ -156,7 +156,7 @@ union f77_value {
    primme_target *target_v;
    double *double_v;
    long int *long_int_v;
-   FILE *file_v;
+   FILE **file_v;
    primme_init *init_v;
    primme_projection *projection_v;
    primme_restartscheme *restartscheme_v;


### PR DESCRIPTION
Hi there,

I noticed that the Fortran interface to PRIMME doesn't behave properly when the user tries to set the output file via primme_set_member_f77 + PRIMMEF77_outputFile.

The problem is that primme_set_member_f77 expects to receive a file pointer (*FILE), which is impossible to send via Fortran. Fortran always passes arguments by reference, so we can only effectively pass a pointer to a file pointer (**FILE). As a file pointer cannot be dereferenced, there is no way for a Fortran code to pass directly a file (FILE) with the hope of that turning into a file pointer (*FILE).

Thanks,
Felipe