### PR TITLE
regularize header file name for cross-compilation

### DIFF
--- a/src/linalg/wtime.c
+++ b/src/linalg/wtime.c
@@ -78,7 +78,7 @@ double primme_wTimer(int zeroTimer) {
 
 #else
 
-#include <Windows.h>
+#include <windows.h>
 double primme_wTimer() {
    return GetTickCount();
 }


### PR DESCRIPTION
To allow cross-compiling for Windows (e.g., with MinGW) the system header file names should be in lower case. (Since the native Windows file systems are case-insensitive this should only matter for cross compilation.)